### PR TITLE
Implement Swagger API Documentation and POST /login path documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "redis": "^4.6.14",
         "rimraf": "^5.0.6",
         "source-map-support": "^0.5.21",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^10.0.0",
         "validator": "^13.12.0"
       },
@@ -39,6 +40,7 @@
         "@types/pg": "^8.11.6",
         "@types/redis": "^4.0.11",
         "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "^4.1.6",
         "@types/uuid": "^10.0.0",
         "@types/validator": "^13.12.0",
         "eslint": "^8.57.0",
@@ -2322,6 +2324,16 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.6.tgz",
+      "integrity": "sha512-UVSiGYXa5IzdJJG3hrc86e8KdZWLYxyEsVoUI4iPXc7CO4VZ3AfNP8d/8+hrDRIqz+HAaSMtZSqAsF3Nq2X/Dg==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@types/uuid": {
@@ -8758,6 +8770,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/pg": "^8.11.6",
     "@types/redis": "^4.0.11",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "^4.1.6",
     "@types/uuid": "^10.0.0",
     "@types/validator": "^13.12.0",
     "eslint": "^8.57.0",
@@ -63,6 +64,7 @@
     "redis": "^4.6.14",
     "rimraf": "^5.0.6",
     "source-map-support": "^0.5.21",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^10.0.0",
     "validator": "^13.12.0"
   },

--- a/src/main/config/app.ts
+++ b/src/main/config/app.ts
@@ -1,10 +1,12 @@
 import express, { Express } from 'express'
 import setupMiddlewares from './middlewares'
 import setupRoutes from './routes'
+import setupSwagger from './swagger'
 import { Server } from 'http'
 
 export const setupApp = async (): Promise<Express> => {
   const app = express()
+  setupSwagger(app)
   setupMiddlewares(app)
   setupRoutes(app)
   return app

--- a/src/main/config/swagger.ts
+++ b/src/main/config/swagger.ts
@@ -1,0 +1,8 @@
+import { serve, setup } from 'swagger-ui-express'
+import { Express } from 'express'
+import swaggerConfig from '@/main/docs'
+import { noCache } from '@/main/middlewares'
+
+export default (app: Express): void => {
+  app.use('/api-docs', noCache, serve, setup(swaggerConfig))
+}

--- a/src/main/docs/components.ts
+++ b/src/main/docs/components.ts
@@ -1,0 +1,17 @@
+import {
+  badRequest,
+  serverError,
+  unauthorized,
+  forbidden
+} from './components/'
+import { apiKeyAuthSchema } from './schemas/'
+
+export default {
+  securitySchemes: {
+    apiKeyAuth: apiKeyAuthSchema
+  },
+  badRequest,
+  serverError,
+  unauthorized,
+  forbidden
+}

--- a/src/main/docs/components/bad-request.ts
+++ b/src/main/docs/components/bad-request.ts
@@ -1,0 +1,10 @@
+export const badRequest = {
+  description: 'Requisição inválida',
+  content: {
+    'application/json': {
+      schema: {
+        $ref: '#/schemas/error'
+      }
+    }
+  }
+}

--- a/src/main/docs/components/forbidden.ts
+++ b/src/main/docs/components/forbidden.ts
@@ -1,0 +1,10 @@
+export const forbidden = {
+  description: 'Acesso negado',
+  content: {
+    'application/json': {
+      schema: {
+        $ref: '#/schemas/error'
+      }
+    }
+  }
+}

--- a/src/main/docs/components/index.ts
+++ b/src/main/docs/components/index.ts
@@ -1,0 +1,4 @@
+export * from './bad-request'
+export * from './forbidden'
+export * from './server-error'
+export * from './unauthorized'

--- a/src/main/docs/components/server-error.ts
+++ b/src/main/docs/components/server-error.ts
@@ -1,0 +1,10 @@
+export const serverError = {
+  description: 'Problema no servidor',
+  content: {
+    'application/json': {
+      schema: {
+        $ref: '#/schemas/error'
+      }
+    }
+  }
+}

--- a/src/main/docs/components/unauthorized.ts
+++ b/src/main/docs/components/unauthorized.ts
@@ -1,0 +1,10 @@
+export const unauthorized = {
+  description: 'Credenciais inválidas',
+  content: {
+    'application/json': {
+      schema: {
+        $ref: '#/schemas/error'
+      }
+    }
+  }
+}

--- a/src/main/docs/index.ts
+++ b/src/main/docs/index.ts
@@ -1,0 +1,34 @@
+import components from './components'
+import schemas from './schemas'
+import paths from './paths'
+
+export default {
+  openapi: '3.0.0',
+  info: {
+    title: 'Chat Auth Node',
+    description: 'API para chat com autenticação',
+    version: '1.0.0',
+    license: {
+      name: 'MIT',
+      url: 'https://github.com/RafaelCava/clean-node-types/blob/master/LICENSE'
+    },
+    contact: {
+      name: 'Rafael Cavalcante',
+      email: 'ra.facavalcante@hotmail.com',
+      url: 'https://www.linkedin.com/in/rafael-cavalcantee/'
+    }
+  },
+  servers: [{
+    url: '/api'
+  }],
+  tags: [{
+    name: 'Users'
+  }, {
+    name: 'Rooms'
+  },{
+    name: 'Auth'
+  }],
+  paths,
+  schemas,
+  components
+}

--- a/src/main/docs/paths.ts
+++ b/src/main/docs/paths.ts
@@ -1,0 +1,5 @@
+import { loginPath } from "./paths/login-path";
+
+export default {
+  '/auth/login': loginPath
+}

--- a/src/main/docs/paths/index.ts
+++ b/src/main/docs/paths/index.ts
@@ -1,0 +1,1 @@
+export * from './login-path'

--- a/src/main/docs/paths/login-path.ts
+++ b/src/main/docs/paths/login-path.ts
@@ -1,0 +1,36 @@
+export const loginPath = {
+  post: {
+    tags: ['Auth'],
+    summary: 'API para autenticar usuário',
+    responses: {
+      200: {
+        description: 'Sucesso',
+        content: {
+          'application/json': {
+            schema: {
+              $ref: '#/schemas/authentication-result'
+            }
+          }
+        }
+      },
+      400: {
+        $ref: '#/components/badRequest'
+      },
+      403: {
+        $ref: '#/components/forbidden'
+      },
+      500: {
+        $ref: '#/components/serverError'
+      }
+    },
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: {
+            $ref: '#/schemas/loginParams'
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/docs/schemas.ts
+++ b/src/main/docs/schemas.ts
@@ -1,0 +1,11 @@
+import {
+  errorSchema,
+  loginParamsSchema,
+  authenticationResultSchema
+} from './schemas/'
+
+export default {
+  error: errorSchema,
+  loginParams: loginParamsSchema,
+  'authentication-result': authenticationResultSchema
+}

--- a/src/main/docs/schemas/api-key-auth-schema.ts
+++ b/src/main/docs/schemas/api-key-auth-schema.ts
@@ -1,0 +1,5 @@
+export const apiKeyAuthSchema = {
+  type: 'apiKey',
+  in: 'header',
+  name: 'x-access-token'
+}

--- a/src/main/docs/schemas/authentication-result-schema.ts
+++ b/src/main/docs/schemas/authentication-result-schema.ts
@@ -1,0 +1,12 @@
+export const authenticationResultSchema = {
+  type: 'object',
+  properties: {
+    accessToken: {
+      type: 'string'
+    },
+    refreshToken: {
+      type: 'string'
+    }
+  },
+  required: ['accessToken', 'refreshToken']
+}

--- a/src/main/docs/schemas/error-schema.ts
+++ b/src/main/docs/schemas/error-schema.ts
@@ -1,0 +1,8 @@
+export const errorSchema = {
+  type: 'object',
+  properties: {
+    error: {
+      type: 'string'
+    }
+  }
+}

--- a/src/main/docs/schemas/index.ts
+++ b/src/main/docs/schemas/index.ts
@@ -1,0 +1,4 @@
+export * from './api-key-auth-schema'
+export * from './error-schema'
+export * from './login-params-schema'
+export * from './authentication-result-schema'

--- a/src/main/docs/schemas/login-params-schema.ts
+++ b/src/main/docs/schemas/login-params-schema.ts
@@ -1,0 +1,12 @@
+export const loginParamsSchema = {
+  type: 'object',
+  properties: {
+    email: {
+      type: 'string'
+    },
+    password: {
+      type: 'string'
+    }
+  },
+  required: ['email', 'password']
+}

--- a/src/main/middlewares/index.ts
+++ b/src/main/middlewares/index.ts
@@ -1,3 +1,4 @@
 export * from './body-parser'
 export * from './content-type'
 export * from './auth'
+export * from './no-cache'

--- a/src/main/middlewares/no-cache.ts
+++ b/src/main/middlewares/no-cache.ts
@@ -1,0 +1,9 @@
+import { NextFunction, Request, Response } from 'express'
+
+export const noCache = (req: Request, res: Response, next: NextFunction): void => {
+  res.set('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+  res.set('pragma', 'no-cache')
+  res.set('expires', '0')
+  res.set('surrogate-control', 'no-store')
+  next()
+}

--- a/tests/main/middlewares/body-parser.test.ts
+++ b/tests/main/middlewares/body-parser.test.ts
@@ -1,0 +1,21 @@
+import { Express } from 'express'
+import request from 'supertest'
+import { setupApp } from '@/main/config/app'
+
+let app: Express
+
+describe('BodyParser', () => {
+  beforeAll(async () => {
+    app = await setupApp()
+  })
+
+  test('Should parse body as json', async () => {
+    app.post('/test_body_parser', (req, res) => {
+      res.send(req.body)
+    })
+    await request(app)
+      .post('/test_body_parser')
+      .send({ name: 'any_name' })
+      .expect({ name: 'any_name' })
+  })
+})

--- a/tests/main/middlewares/content-type.test.ts
+++ b/tests/main/middlewares/content-type.test.ts
@@ -1,0 +1,29 @@
+import { Express } from 'express'
+import request from 'supertest'
+import { setupApp } from '@/main/config/app'
+
+let app: Express
+
+describe('Content Type middleware', () => {
+  beforeAll(async () => {
+    app = await setupApp()
+  })
+
+  test('Should return default content type as json', async () => {
+    app.get('/test_content_type', (req, res) => {
+      res.send('')
+    })
+    await request(app)
+      .get('/test_content_type')
+      .expect('content-type', /json/ig)
+  })
+  test('Should return xml content type when forced', async () => {
+    app.get('/test_content_type_xml', (req, res) => {
+      res.type('xml')
+      res.send('')
+    })
+    await request(app)
+      .get('/test_content_type_xml')
+      .expect('content-type', /xml/ig)
+  })
+})

--- a/tests/main/middlewares/no-cache.test.ts
+++ b/tests/main/middlewares/no-cache.test.ts
@@ -1,0 +1,24 @@
+import request from 'supertest'
+import { noCache } from '@/main/middlewares'
+import { setupApp } from '@/main/config/app'
+import { Express } from 'express'
+
+let app: Express
+
+describe('NoCache middleware', () => {
+  beforeAll(async () => {
+    app = await setupApp()
+  })
+
+  test('Should disable cache', async () => {
+    app.get('/test_no_cache', noCache, (req, res) => {
+      res.send()
+    })
+    await request(app)
+      .get('/test_no_cache')
+      .expect('cache-control', 'no-store, no-cache, must-revalidate, proxy-revalidate')
+      .expect('pragma', 'no-cache')
+      .expect('expires', '0')
+      .expect('surrogate-control', 'no-store')
+  })
+})


### PR DESCRIPTION
# Descrição
Implementando a lib swagger para documentar a api e implementar a documentação da rota POST /login

## 🛠️ Setup
Executar o serviço chat-auth-node

## 💭 Observações
N/A

## Teste

### ▶️ Cenário de teste
1. acessar a rota /api-docs

#### ✔️ Resultado esperado
Acessar a documentação da aplicação

## 🚢 Ao deployar
Validar que a documentação esta renderizando e realizando as requisições